### PR TITLE
New support channel

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ are using [`ethers.js`](https://ethers.org) in our tests, which is the most popu
 
 ## Get in Touch
 
-If you’d like to talk to us, please join [our Discord](https://discord.gg/bKza3GEBEA) and say hello.
+If you’d like to talk to us, please join [Polkadot Discord](https://discord.gg/polkadot), find our support channel under `Technical -> solidity-smart-contracts` and say hello.
 This is also where we handle support questions. If you found a bug, please [report it](https://github.com/paritytech/contract-issues),
 but make sure to check the [known issues](/known_issues) first.
 


### PR DESCRIPTION
If I get more permissions, I might be able to create a link to the exact room as well, but it is not that different for new server users: https://www.reddit.com/r/discordapp/comments/6i79zb/link_directly_to_a_specific_channel_on_a_server/