### PR TITLE
Fix network name and token name

### DIFF
--- a/src/components/WalletConnect.tsx
+++ b/src/components/WalletConnect.tsx
@@ -16,10 +16,10 @@ const Westend = {
   chainNamespace: 'eip155',
   chainId: 420420421,
   caipNetworkId: 'eip155:420420421',
-  name: 'Asset Hub Westend',
+  name: 'Westend Asset Hub',
   nativeCurrency: {
     name: 'Westie',
-    symbol: 'WST',
+    symbol: 'WND',
     decimals: 18,
   },
   rpcUrls: {


### PR DESCRIPTION
Metamask issues a warning because the token and network name wasn't matching the upstream chain definition.

Need to change network name to just Westend once https://github.com/ethereum-lists/chains/pull/7151 is merged.