### PR TITLE
Remove all mentions of Asset Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Contracts Docs
 
-This is the documentation for smart contracts on Asset Hub. It is built using Docusaurus. Master is deployed to: https://contracts.polkadot.io.
+This is the documentation for smart contracts on Polkadot. It is built using Docusaurus. Master is deployed to: https://contracts.polkadot.io.
 
 ## Local Development
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 :::warning
 
-**The feature is a work in progress**. A preview version is deployed to the [Westend Asset Hub Parachain](https://wiki.polkadot.network/docs/maintain-networks#westend-asset-hub)
+**The feature is a work in progress**. A preview version is deployed to the [Westend Network](https://docs.polkadot.com/develop/networks/#westend)
 to gather feedback during development. **This documentation is also temporary and will be moved to [docs.polkadot.com](https://docs.polkadot.com/) in 2025 once the feature is in production.**
 
 :::

--- a/docs/tutorial/1-connect-to-westend.md
+++ b/docs/tutorial/1-connect-to-westend.md
@@ -1,11 +1,11 @@
 ---
 sidebar_position: 1
-slug: /connect-to-asset-hub
+slug: /connect-to-westend
 ---
 
 import {WalletConnectButton} from '@site/src/components/WalletConnect'
 
-# Connect to Asset Hub
+# Connect to Westend
 
 - Install an Ethereum wallet of your choice, such as [Talisman] or [MetaMask] browser extension.
 - Create a new Ethereum account (if you don’t already have one).
@@ -16,16 +16,16 @@ MetaMask enforces Ethereum contract size limits. If you want to deploy larger co
 
 :::
 
-# Connect to Asset Hub Westend Testnet (Applicable to MetaMask only)
+# Connect to Westend (Applicable to MetaMask only)
 
-Connect your MetaMask wallet to Asset Hub using the following link:
+Connect your MetaMask wallet to Westend using the following link:
 
 <WalletConnectButton />
 <br /><sub><sup>(Try reloading the page if the link does not work)</sup></sub>
 
 <details>
 <summary>Or add it manually</summary>
-- Network name: Asset-Hub Westend Testnet
+- Network name: Westend
 - RPC URL URL: `https://westend-asset-hub-eth-rpc.polkadot.io`
 - Chain ID: `420420421`
 - Currency Symbol: `WND`

--- a/docs/tutorial/2-deploy-your-first-contract.md
+++ b/docs/tutorial/2-deploy-your-first-contract.md
@@ -20,7 +20,7 @@ This guide will walk you through deploying and interacting with contracts in REM
    1. Using Talisman wallet
 
       Select the **Injected Provider - Talisman** environment in the **Deploy & Run** tab. When prompted, allow Remix to connect to Talisman.
-      Switch to the **Westend Asset Hub** network in Talisman. Make sure **Enable Testnets** is checked in Talisman to see the network.
+      Switch to the **Westend** network in Talisman. Make sure **Enable Testnets** is checked in Talisman to see the network.
       Your account address and balance will appear under the **ACCOUNT** section. Remix will automatically use the network selected in Talisman.
 
       ![Deploy contract](img/dapp_deploy_with_talisman.png)
@@ -31,7 +31,7 @@ This guide will walk you through deploying and interacting with contracts in REM
 
       Select **Injected Provider - MetaMask** environment in the **Deploy & Run** tab.
       When prompted, allow REMIX to connect to MetaMask. Your account address and balance will be displayed under the **ACCOUNT** section.
-      Ensure you are connected to the **Asset-Hub Westend** network in MetaMask. If you are not already connected, switch to the correct network. Remix will automatically use the network selected in MetaMask.
+      Ensure you are connected to the **Westend** network in MetaMask. If you are not already connected, switch to the correct network. Remix will automatically use the network selected in MetaMask.
 
       ![Deploy contract](img/dapp_deploy.png)
 

--- a/docs/tutorial/try.md
+++ b/docs/tutorial/try.md
@@ -116,7 +116,7 @@ extrinsics. We’re using the `1_Storage.sol` example contract here, which you c
 
 When registering, you will sign the transaction with a Polkadot native wallet and signature scheme, likely even a pre-existing
 account. To use a Polkadot native wallet, you need to register (or "map") your account with `pallet_revive`. This is a one-time
-action and is necessary to enable mapping between the Asset Hub-native and Ethereum addresses. Ethereum wallets don't require any registration.
+action and is necessary to enable mapping between the Polkadot and Ethereum addresses. Ethereum wallets don't require any registration.
 
 1. Go to Polkadot.js Apps, connect to Westend AssetHub, and go to the `Developer -> Extrinsics` tab.
 [Here](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwestend-asset-hub-rpc.polkadot.io#/extrinsics) is a direct link.

--- a/src/components/WalletConnect.tsx
+++ b/src/components/WalletConnect.tsx
@@ -6,7 +6,7 @@ const projectId = 'c1455e18050fa3e0857a79ac38187ba5'
 
 const metadata = {
   name: 'contracts-doc',
-  description: 'Asset Hub Westend - Contracts Documentation',
+  description: 'Westend - Contracts Documentation',
   url: 'https://reown.com/appkit', // origin must match your domain & subdomain
   icons: ['https://assets.reown.com/reown-profile-pic.png'],
 }
@@ -16,7 +16,7 @@ const Westend = {
   chainNamespace: 'eip155',
   chainId: 420420421,
   caipNetworkId: 'eip155:420420421',
-  name: 'Westend Asset Hub',
+  name: 'Westend',
   nativeCurrency: {
     name: 'Westie',
     symbol: 'WND',


### PR DESCRIPTION
We should just refer to everything by its network name (Polkadot, Kusama, Westend). AssetHub is an implementation detail.

This will also change the network name in wallet connect to just "Westend". It will through a warning until https://github.com/ethereum-lists/chains/pull/7151 is merged, though.